### PR TITLE
Support for sql statements + default column values during migrations

### DIFF
--- a/JetEntityFrameworkProvider/GeneratorDdl/JetDdlBuilder.cs
+++ b/JetEntityFrameworkProvider/GeneratorDdl/JetDdlBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Entity.Core.Metadata.Edm;
+using System.Data.Entity.Migrations.Model;
 using System.Linq;
 using System.Text;
 
@@ -54,12 +55,17 @@ namespace JetEntityFrameworkProvider
 
         public void AppendType(EdmProperty column)
         {
-            AppendType(column.TypeUsage, column.Nullable, column.TypeUsage.GetIsIdentity());
+            AppendType(column.TypeUsage, column.Nullable, column.TypeUsage.GetIsIdentity(), column.DefaultValue.ToString());
         }
 
-        public void AppendType(TypeUsage typeUsage, bool isNullable, bool isIdentity)
+        public void AppendType(ColumnModel column)
         {
+            TypeUsage storeType = JetProviderManifest.Instance.GetStoreType(column.TypeUsage);
+            AppendType(storeType, column.IsNullable ?? true, column.IsIdentity, column.DefaultValueSql);
+        }
 
+        public void AppendType(TypeUsage typeUsage, bool isNullable, bool isIdentity, string defaultValue)
+        {
             bool isTimestamp = false;
 
             JetDataTypeAlias alias;
@@ -90,6 +96,8 @@ namespace JetEntityFrameworkProvider
 
             AppendSql(jetTypeName);
             AppendSql(jetLength);
+            if (!string.IsNullOrWhiteSpace(defaultValue))
+                AppendSql(" DEFAULT " + defaultValue);
             AppendSql(isNullable ? " null" : " not null");
 
             if (isTimestamp)

--- a/JetEntityFrameworkProvider/GeneratorDdl/JetMigrationSqlGenerator.cs
+++ b/JetEntityFrameworkProvider/GeneratorDdl/JetMigrationSqlGenerator.cs
@@ -407,5 +407,9 @@ namespace JetEntityFrameworkProvider
 
         #endregion
 
+        private string GenerateSqlStatementConcrete(SqlOperation migrationOperation)
+        {
+            return migrationOperation.Sql;
+        }
     }
 }

--- a/JetEntityFrameworkProvider/GeneratorDdl/JetMigrationSqlGenerator.cs
+++ b/JetEntityFrameworkProvider/GeneratorDdl/JetMigrationSqlGenerator.cs
@@ -191,8 +191,7 @@ namespace JetEntityFrameworkProvider
 
             ddlBuilder.AppendIdentifier(column.Name);
             ddlBuilder.AppendSql(" ");
-            TypeUsage storeType = JetProviderManifest.Instance.GetStoreType(column.TypeUsage);
-            ddlBuilder.AppendType(storeType, column.IsNullable ?? true, column.IsIdentity);
+            ddlBuilder.AppendType(column);
             ddlBuilder.AppendNewLine();
 
 
@@ -224,8 +223,7 @@ namespace JetEntityFrameworkProvider
 
             ddlBuilder.AppendIdentifier(column.Name);
             ddlBuilder.AppendSql(" ");
-            TypeUsage storeType = JetProviderManifest.Instance.GetStoreType(column.TypeUsage);
-            ddlBuilder.AppendType(storeType, column.IsNullable ?? true, column.IsIdentity);
+            ddlBuilder.AppendType(column);
             ddlBuilder.AppendNewLine();
 
 
@@ -297,8 +295,7 @@ namespace JetEntityFrameworkProvider
 
                 ddlBuilder.AppendIdentifier(column.Name);
                 ddlBuilder.AppendSql(" ");
-                TypeUsage storeType = JetProviderManifest.Instance.GetStoreType(column.TypeUsage);
-                ddlBuilder.AppendType(storeType, column.IsNullable ?? true, column.IsIdentity);
+                ddlBuilder.AppendType(column);
                 ddlBuilder.AppendSql(BATCHTERMINATOR);
             }
 
@@ -325,8 +322,7 @@ namespace JetEntityFrameworkProvider
                 ddlBuilder.AppendSql(" ");
                 ddlBuilder.AppendIdentifier(column.Name);
                 ddlBuilder.AppendSql(" ");
-                TypeUsage storeTypeUsage = ProviderManifest.GetStoreType(column.TypeUsage);
-                ddlBuilder.AppendType(storeTypeUsage, column.IsNullable ?? true, column.IsIdentity);
+                ddlBuilder.AppendType(column);
                 ddlBuilder.AppendNewLine();
             }
 


### PR DESCRIPTION
The following adds support for:
1. SQL statements within Up/Down migration methods by calling the "Sql" method of the DbMigration class
2. define a custom default value when adding columns during migration process using the "defaultValueSql" property, for example:
`AddColumn("table", "Column", c => c.Int(nullable: false, defaultValueSql: "0"));`